### PR TITLE
fix/return bad request when creating incidents with unknown categories

### DIFF
--- a/src/main/java/se/sundsvall/incident/service/IncidentService.java
+++ b/src/main/java/se/sundsvall/incident/service/IncidentService.java
@@ -1,5 +1,5 @@
 package se.sundsvall.incident.service;
-
+import static org.zalando.problem.Status.BAD_REQUEST;
 import static org.zalando.problem.Status.NOT_FOUND;
 import static se.sundsvall.incident.service.mapper.Mapper.toIncidentEntity;
 import static se.sundsvall.incident.service.mapper.Mapper.toIncidentOepResponse;
@@ -81,7 +81,7 @@ public class IncidentService {
 	@Transactional
 	public IncidentSaveResponse createIncident(final IncidentSaveRequest request) {
 		var category = categoryRepository.findById(request.getCategory())
-			.orElseThrow(() -> Problem.valueOf(NOT_FOUND, ENTITY_NOT_FOUND.formatted(CATEGORY, request.getCategory())));
+			.orElseThrow(() -> Problem.valueOf(BAD_REQUEST, ENTITY_NOT_FOUND.formatted(CATEGORY, request.getCategory())));
 		var attachments = Optional.ofNullable(request.getAttachments())
 			.map(list -> list.stream()
 				.map(Mapper::toAttachmentEntity)

--- a/src/test/java/se/sundsvall/incident/service/IncidentServiceTest.java
+++ b/src/test/java/se/sundsvall/incident/service/IncidentServiceTest.java
@@ -138,7 +138,8 @@ class IncidentServiceTest {
 
 		assertThatThrownBy(() -> incidentService.createIncident(request))
 			.isInstanceOf(Problem.class)
-			.hasMessageContaining("Not Found: Category with id: ");
+			.hasMessageContaining("Bad Request: Category with id: ")
+			.extracting("status").isEqualTo(BAD_REQUEST);
 
 		verify(mockCategoryRepository).findById(request.getCategory());
 		verify(mockIncidentRepository, never()).save(any());

--- a/src/test/java/se/sundsvall/incident/service/IncidentServiceTest.java
+++ b/src/test/java/se/sundsvall/incident/service/IncidentServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.zalando.problem.Status.BAD_REQUEST;
 import static se.sundsvall.incident.TestDataFactory.createCategoryEntity;
 import static se.sundsvall.incident.TestDataFactory.createIncidentEntity;
 import static se.sundsvall.incident.TestDataFactory.createIncidentSaveRequest;


### PR DESCRIPTION
This is supposed to be a fix for issue #63 : https://github.com/Sundsvallskommun/api-service-incident/issues/63